### PR TITLE
doc: fix typo in allowed callback url

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Your user will be redirected to Kinde to authenticate. After they have logged in
 
 You need to specify in Kinde which url you would like your user to be redirected to in order to authenticate your app.
 
-On the `Settings -> Applications -> Backend app` page set `Allowed callback URLs` to `http://localhost:3000/api/auth/callback`
+On the `Settings -> Applications -> Backend app` page set `Allowed callback URLs` to `http://localhost:3000/api/callback`
 
 > Important! This is required for your users to successfully log in to your app.
 


### PR DESCRIPTION
# Explain your changes

Updates documentation by fixing a typo in the `Allowed callback URLs` from `/api/auth/callback` to `/api/callback`

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-starter-kits/.github/blob/ff8d5c462e56772810bca53f750fd3610a00d673/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-starter-kits/.github/blob/ff8d5c462e56772810bca53f750fd3610a00d673/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-starter-kits/.github/blob/ff8d5c462e56772810bca53f750fd3610a00d673/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
