### PR TITLE
fix: added a clean up to the run dev and add a prod run step

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "scripts": {
     "build": "nuxt build",
-    "dev": "nuxt dev",
+    "dev": "rm -rf .output && npx nuxt dev",
+    "prod": "npx nuxt start",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "build": "nuxt build",
-    "dev": "rm -rf .output && npx nuxt dev",
+    "dev": "rimraf .output && npx nuxt dev",
     "prod": "npx nuxt start",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
@@ -16,6 +16,7 @@
     "vue-router": "^4.2.5"
   },
   "dependencies": {
-    "@nuxtjs/kinde": "^0.1.6"
+    "@nuxtjs/kinde": "^0.1.6",
+    "rimraf": "^6.0.1"
   }
 }


### PR DESCRIPTION
# Explain your changes

This change prevents a user from attempting to run a project on production output. This causes issues as the projection and dev modes work differently.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-starter-kits/.github/blob/ff8d5c462e56772810bca53f750fd3610a00d673/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-starter-kits/.github/blob/ff8d5c462e56772810bca53f750fd3610a00d673/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-starter-kits/.github/blob/ff8d5c462e56772810bca53f750fd3610a00d673/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new command to start the application in production mode.
  
- **Improvements**
	- Updated the development script to include cleanup of the output directory before starting the development server.
	- Added a new dependency for improved script management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->